### PR TITLE
Allow override of Guzzle Timeout

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -34,7 +34,7 @@ class ApiClient
 
         $this->fetcher = new Guzzle([
             'base_uri' => 'https://api.workflowmax.com/',
-            'timeout'  => 30.0,
+            'timeout'  => (isset($params['timeout'])) ? $params['timeout'] : 30.0,
         ]);
     }
 


### PR DESCRIPTION
Have run into issue where Workflowmax frequently takes longer than 30s to respond.
Therefore have added the ability for the Guzzle timeout setting to be overridden in the parameters of the ApiClient constructor.